### PR TITLE
ElasticSearchConfig replacable

### DIFF
--- a/fhdp/fhdp-commons/fhdp-commons-els/src/main/java/pl/fhframework/dp/commons/els/config/ElasticSearchConfig.java
+++ b/fhdp/fhdp-commons/fhdp-commons-els/src/main/java/pl/fhframework/dp/commons/els/config/ElasticSearchConfig.java
@@ -8,19 +8,28 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
 import org.springframework.data.elasticsearch.client.reactive.ReactiveRestClients;
 import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -31,86 +40,32 @@ import java.util.regex.Pattern;
  */
 @Configuration
 @EnableElasticsearchRepositories(basePackages = {"pl.fhframework.dp"})
+@ComponentScan(value = "pl.fhframework.dp.commons.els.config")
 public class ElasticSearchConfig extends ElasticsearchConfigurationSupport {
     private final Logger logger = LoggerFactory.getLogger(ElasticSearchConfig.class);
 
-
-    @Value("${elasticSearch.hostAndPort:localhost:9200}")
-    private String hostAndPort;
-
-    @Getter
-    @Value("${elasticSearch.indexNamePrefix:}")
-    private String indexNamePrefix;
-    @Getter
-    @Value("${elasticSearch.maxConnPerRoute:150}")
-    private int maxConnPerRoute;
-    @Getter
-    @Value("${elasticSearch.maxConnTotal:300}")
-    private int maxConnTotal;
-    @Getter
-    @Value("${elasticSearch.socketTimeout:60000}")
-    private int socketTimeout;
+    @Autowired
+    private ElasticSearchParams elasticSearchParams;
 
     @Bean
     public String indexNamePrefix() {
-        return indexNamePrefix;
+        return elasticSearchParams.getIndexNamePrefix();
     }
 
     @Bean
     public RestHighLevelClient elasticsearchClient() throws Exception {
-
-//        hostAndPort = System.getProperty("elasticSearch.hostAndPort", null);
-        logger.info("******** Initial hostAndPort: {} (system property elasticSearch.hostAndPort)", hostAndPort);
-        logger.info("******** Initial indexNamePrefix: {} (system property elasticSearch.indexNamePrefix)", indexNamePrefix);
-        String [] hosts = hostAndPort.split(Pattern.quote(","));
-
-        HttpHost[] httpHosts = createHosts(hosts);
-        RestClientBuilder builder = RestClient.builder(httpHosts);
-        builder.setRequestConfigCallback(
-                requestConfigBuilder -> requestConfigBuilder
-                        .setConnectTimeout(15000)
-                        .setSocketTimeout(socketTimeout));
-        builder.setHttpClientConfigCallback(httpAsyncClientBuilder -> {
-            httpAsyncClientBuilder.setMaxConnPerRoute(maxConnPerRoute)
-                    .setMaxConnTotal(maxConnTotal)
-                    .setDefaultIOReactorConfig(IOReactorConfig.custom()
-                            .setSoKeepAlive(true)
-                            .build());
-            return httpAsyncClientBuilder;
-        });
-        return new RestHighLevelClient(builder);
-    }
-
-    private HttpHost[] createHosts(String[] hosts) {
-        List<HttpHost> list = new ArrayList<>();
-        for(String host: hosts) {
-            String[] elements = host.split(Pattern.quote(":"));
-            list.add(new HttpHost(elements[0], Integer.parseInt(elements[1]), "http"));
-        }
-        return list.toArray(new HttpHost[0]);
+        return elasticSearchParams.elasticsearchClient();
     }
 
     @Bean
     ReactiveElasticsearchClient client() {
-        String [] hosts = hostAndPort.split(Pattern.quote(","));
-        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo(hosts)
-                .withWebClientConfigurer(webClient -> {
-                    ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
-                            .codecs(configurer -> configurer.defaultCodecs()
-                                    .maxInMemorySize(-1))
-                            .build();
-                    return webClient.mutate().exchangeStrategies(exchangeStrategies).build();
-                })
-                .build();
-
-        return ReactiveRestClients.create(clientConfiguration);
+        return elasticSearchParams.client();
     }
 
-    @Bean
-    public ElasticsearchOperations elasticsearchTemplate(RestHighLevelClient elasticsearchClient) throws Exception{
-        return new ElasticsearchRestTemplate(elasticsearchClient);
-    }
+    //@Bean
+    //public ElasticsearchOperations elasticsearchTemplate(RestHighLevelClient elasticsearchClient) throws Exception{
+    //    return new ElasticsearchRestTemplate(elasticsearchClient);
+    //}
 
 
 //    @WritingConverter

--- a/fhdp/fhdp-commons/fhdp-commons-els/src/main/java/pl/fhframework/dp/commons/els/config/ElasticSearchConfig.java
+++ b/fhdp/fhdp-commons/fhdp-commons-els/src/main/java/pl/fhframework/dp/commons/els/config/ElasticSearchConfig.java
@@ -62,10 +62,10 @@ public class ElasticSearchConfig extends ElasticsearchConfigurationSupport {
         return elasticSearchParams.client();
     }
 
-    //@Bean
-    //public ElasticsearchOperations elasticsearchTemplate(RestHighLevelClient elasticsearchClient) throws Exception{
-    //    return new ElasticsearchRestTemplate(elasticsearchClient);
-    //}
+    @Bean
+    public ElasticsearchOperations elasticsearchTemplate(RestHighLevelClient elasticsearchClient) throws Exception{
+        return new ElasticsearchRestTemplate(elasticsearchClient);
+    }
 
 
 //    @WritingConverter

--- a/fhdp/fhdp-commons/fhdp-commons-els/src/main/java/pl/fhframework/dp/commons/els/config/ElasticSearchParams.java
+++ b/fhdp/fhdp-commons/fhdp-commons-els/src/main/java/pl/fhframework/dp/commons/els/config/ElasticSearchParams.java
@@ -1,0 +1,91 @@
+package pl.fhframework.dp.commons.els.config;
+
+import lombok.Getter;
+import org.apache.http.HttpHost;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveRestClients;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Component
+public class ElasticSearchParams {
+    private final Logger logger = LoggerFactory.getLogger(ElasticSearchParams.class);
+
+    @Value("${elasticSearch.hostAndPort:localhost:9200}")
+    private String hostAndPort;
+
+    @Getter
+    @Value("${elasticSearch.indexNamePrefix:}")
+    private String indexNamePrefix;
+    @Getter
+    @Value("${elasticSearch.maxConnPerRoute:150}")
+    private int maxConnPerRoute;
+    @Getter
+    @Value("${elasticSearch.maxConnTotal:300}")
+    private int maxConnTotal;
+    @Getter
+    @Value("${elasticSearch.socketTimeout:60000}")
+    private int socketTimeout;
+
+    public RestHighLevelClient elasticsearchClient() throws Exception {
+
+//        hostAndPort = System.getProperty("elasticSearch.hostAndPort", null);
+        logger.info("******** Initial hostAndPort: {} (system property elasticSearch.hostAndPort)", hostAndPort);
+        logger.info("******** Initial indexNamePrefix: {} (system property elasticSearch.indexNamePrefix)", indexNamePrefix);
+        String [] hosts = hostAndPort.split(Pattern.quote(","));
+
+        HttpHost[] httpHosts = createHosts(hosts);
+        RestClientBuilder builder = RestClient.builder(httpHosts);
+        builder.setRequestConfigCallback(
+                requestConfigBuilder -> requestConfigBuilder
+                        .setConnectTimeout(15000)
+                        .setSocketTimeout(socketTimeout));
+        builder.setHttpClientConfigCallback(httpAsyncClientBuilder -> {
+            httpAsyncClientBuilder.setMaxConnPerRoute(maxConnPerRoute)
+                    .setMaxConnTotal(maxConnTotal)
+                    .setDefaultIOReactorConfig(IOReactorConfig.custom()
+                            .setSoKeepAlive(true)
+                            .build());
+            return httpAsyncClientBuilder;
+        });
+        return new RestHighLevelClient(builder);
+    }
+
+    private HttpHost[] createHosts(String[] hosts) {
+        List<HttpHost> list = new ArrayList<>();
+        for(String host: hosts) {
+            String[] elements = host.split(Pattern.quote(":"));
+            list.add(new HttpHost(elements[0], Integer.parseInt(elements[1]), "http"));
+        }
+        return list.toArray(new HttpHost[0]);
+    }
+
+    public ReactiveElasticsearchClient client() {
+        String [] hosts = hostAndPort.split(Pattern.quote(","));
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .connectedTo(hosts)
+                .withWebClientConfigurer(webClient -> {
+                    ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+                            .codecs(configurer -> configurer.defaultCodecs()
+                                    .maxInMemorySize(-1))
+                            .build();
+                    return webClient.mutate().exchangeStrategies(exchangeStrategies).build();
+                })
+                .build();
+
+        return ReactiveRestClients.create(clientConfiguration);
+    }
+}
+

--- a/fhdp/fhdp-commons/fhdp-commons-services/src/main/java/pl/fhframework/dp/commons/services/facade/GenericDtoService.java
+++ b/fhdp/fhdp-commons/fhdp-commons-services/src/main/java/pl/fhframework/dp/commons/services/facade/GenericDtoService.java
@@ -21,7 +21,7 @@ import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilde
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 import pl.fhframework.dp.commons.base.model.IPersistentObject;
-import pl.fhframework.dp.commons.els.config.ElasticSearchConfig;
+import pl.fhframework.dp.commons.els.config.ElasticSearchParams;
 import pl.fhframework.dp.commons.utils.conversion.BeanConversionUtil;
 import pl.fhframework.dp.transport.dto.commons.BaseDtoQuery;
 import pl.fhframework.dp.transport.service.IDtoService;
@@ -44,7 +44,7 @@ public abstract class GenericDtoService<ID,
         ENTITY> implements IDtoService<ID, DTO , LIST , QUERY> {
 
     @Autowired
-    ElasticSearchConfig elasticSearchConfig;
+    ElasticSearchParams elasticSearchParams;
     @Autowired
     protected ElasticsearchOperations elasticsearchTemplate;
     private Class<LIST> listClazz;
@@ -129,7 +129,7 @@ public abstract class GenericDtoService<ID,
         try {
             Method method = annotation.annotationType().getDeclaredMethod("indexName");
             String value = (String) method.invoke(annotation, (Object[])null);
-            return value.replace("#{@indexNamePrefix}", elasticSearchConfig.getIndexNamePrefix());
+            return value.replace("#{@indexNamePrefix}", elasticSearchParams.getIndexNamePrefix());
         } catch (Exception e) {
             log.error("{}{}", e.getMessage(), e);
         }


### PR DESCRIPTION
Enables use of ElasticSearchConfig from FH without changes in existing applications, but also enables other applications that do not want/can use this configuration and instead can use their own ESL configurations (for example with different ES repositories)